### PR TITLE
AttackDamage: Fixed bug with the bonus damage not updating properly. …

### DIFF
--- a/wurst/HeroMechanics/AttackDamage.wurst
+++ b/wurst/HeroMechanics/AttackDamage.wurst
@@ -1,8 +1,10 @@
 package AttackDamage
 import HashMap
 import RegisterEvents
+import TimerUtils
 
 HashMap<unit, int> unitDamage = new HashMap<unit, int>
+unit unitToUpdate = null
 
 /** Gets the total attack damage of the unit (base + bonus)
     damage.*/
@@ -33,26 +35,34 @@ function unit.setBonusAttackDamage(int damage)
     int dmg1 = remainingDamage div 1
 
     this.setAbilityLevel('A003', dmg100+1)
-    this.setAbilityLevel('A001', dmg10+1)
+    this.setAbilityLevel('A001', dmg10+1)   
     this.setAbilityLevel('A002', dmg1+1)
 
 
+
 function updateAttackDamage()
-    unit unitToUpdate = GetManipulatingUnit()
+    GetExpiredTimer().release()
     int totalDamage = 0
 
-    if unitToUpdate.isType(UNIT_TYPE_HERO)
+    print("update AD: "+unitToUpdate.getName()+" manipulated item!")
         
-        for itemSlot=0 to 5
-            int itemInSlot = UnitItemInSlot(unitToUpdate, itemSlot).getTypeId()
-            if AttackDamageItem.items.has(itemInSlot)
-                totalDamage += AttackDamageItem.items.get(itemInSlot)            
+    for itemSlot=0 to 5
+        int itemInSlot = UnitItemInSlot(unitToUpdate, itemSlot).getTypeId()
+        if AttackDamageItem.items.has(itemInSlot)
+            totalDamage += AttackDamageItem.items.get(itemInSlot)            
 
-        if unitDamage.has(unitToUpdate)
-            unitDamage.getAndRemove(unitToUpdate)
-            
-        unitDamage.put(unitToUpdate, totalDamage)
-        unitToUpdate.setBonusAttackDamage(totalDamage)
+    if unitDamage.has(unitToUpdate)
+        unitDamage.getAndRemove(unitToUpdate)
+        
+    unitDamage.put(unitToUpdate, totalDamage)
+    unitToUpdate.setBonusAttackDamage(totalDamage)
+
+
+function manipulatesItem()
+    
+    if GetManipulatingUnit().isType(UNIT_TYPE_HERO)
+        unitToUpdate = GetManipulatingUnit()
+        getTimer().start(0.01, function updateAttackDamage )
 
 
 class AttackDamageItem
@@ -70,8 +80,8 @@ init
     new AttackDamageItem( 'I00L', 10 )
     new AttackDamageItem( 'I00F', 10 )
 
-    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_PAWN_ITEM, function updateAttackDamage)
-    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_DROP_ITEM, function updateAttackDamage)
-    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_PICKUP_ITEM, function updateAttackDamage)
-    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SELL_ITEM, function updateAttackDamage)
-    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_USE_ITEM, function updateAttackDamage)
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_PAWN_ITEM, function manipulatesItem)
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_DROP_ITEM, function manipulatesItem)
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_PICKUP_ITEM, function manipulatesItem)
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SELL_ITEM, function manipulatesItem)
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_USE_ITEM, function manipulatesItem)

--- a/wurst/Round.wurst
+++ b/wurst/Round.wurst
@@ -238,7 +238,6 @@ public class Round
             error("No more rounds")
 
 
-
     static function setRoundReady()
         aRoundIsRunning = false
 

--- a/wurst/ToDo
+++ b/wurst/ToDo
@@ -12,7 +12,7 @@ TO DO
     [x] Game Initializer
     [x] Between Rounds (Round starter)
 
-[ ] 3) Hero_______________________
+[x] 3) Hero_______________________
     [x] AttackDamage System
     [x] Life Orbs
     [x] Hero Unit
@@ -53,6 +53,7 @@ TO DO
 [x] 9) Music
 
 [ ] 10) Bonus Stuff
+    [ ] Fix Bug with attack damage items
     [ ] Make food into round numbers
     [ ] Change attackDamage to Power
     [ ] Change minimap to all black


### PR DESCRIPTION
…If you dropped an item it didn't register the last item dropped when recalculating the AD, because the recalcuation was actually happening before the item had left the hero's inventory.